### PR TITLE
Correção do link de download do pacote, na função 'install()

### DIFF
--- a/mz
+++ b/mz
@@ -199,9 +199,9 @@ def install():
                     pkglist = ''
 
                     if pkgcount == 1:
-                        install = input('You like install ' + packages[0].replace('.mz', '') + ' ? [Y/n] : ')
+                        install = input('Do you like install ' + packages[0].replace('.mz', '') + ' ? [Y/n] : ')
                         if install == 'Y' or install == 'y':
-                            os.system('wget -O /tmp/' + packages[0] + ' ' + url + links[0])
+                            os.system('wget -O /tmp/' + packages[0] + ' ' + links[0])
                             os.system('banana install ' + '/tmp/' + packages[0])
                             os.system('rm ' + '/tmp/' + packages[0])
                         else:

--- a/mz
+++ b/mz
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
-########################################################
-#                                                      #
-#                mz python3 - v1.0.0.1                 #
-#            Created: Diego Sarzi - 2019               #
-#            Updated: Vovolinux- 14/07/2019            #
-#                   License: MIT                       #
-#                                                      #
+########################################################                                                                            #
+# mz python3 - v1.0.2                                  #
+# Author: Diego Sarzi <diegosarzi@gmail.com> - 2019    #
+# Updated: Vovolinux - 2019                            #
+# License: All files: MIT                              #
 ########################################################
 
 #------------------- VARIABLES ------------------------>

--- a/mz_pt_BR
+++ b/mz_pt_BR
@@ -7,7 +7,7 @@
 # Licença: Todos os arquivos : MIT                     #
 ########################################################
 
-#------------------- VARIABLES ------------------------>
+#------------------- VARIÁVEIS ------------------------>
 
 # Diretórios
 url     = 'http://mazonos.com/packages/' # Repositório oficial
@@ -38,10 +38,10 @@ chooses = [
 
 modules = ['requests', 'bs4']
 
-#------------------- END VARIABLES -------------------->
+#------------------- FIM VARIÁVEIS -------------------->
 
 
-#------------------- IMPORTS -------------------------->
+#------------------- IMPORTAÇÕES ---------------------->
 
 import sys, os, csv, threading, itertools, time, re
 
@@ -67,19 +67,19 @@ import requests, bs4
 from urllib.request import urlopen
 from bs4 import BeautifulSoup
 
-#------------------- END IMPORTS ---------------------->
+#------------------- FIM IMPORTAÇÕES ------------------>
 
 
 
-#------------------- FUNCTIONS ------------------------>
+#------------------- FUNÇÕES -------------------------->
 
 def check():
-    # Checks if the folder exists
+    # Verifica se o diretório existe
     if not os.path.isdir(dircsv):
         os.mkdir(dircsv)
         print('Criando diretório ' + dircsv + '.')
 
-    # Checks if the file exists
+    # Verifica se o arquivo existe
     if not os.path.isfile(filecsv):
         os.system('touch ' + filecsv)
         print('Criando arquivo ' + filecsv + '.')
@@ -136,8 +136,7 @@ def animate():
     text = textAnimate.replace('Pesquisando...','Pesquisa ').replace('Atualizando... ','Atualização ') + 'concluída!'
     sys.stdout.write('\r' + text + '\n')
 
-
-##------------------ CHOOSE-FUNCTIONS ----------------->
+##-------------- FUNÇÕES DE OPÇÔES DO MENU ------------>
 
 def s():
     search()
@@ -152,7 +151,7 @@ def search():
         global found
         package = str(sys.argv[2])
 
-        ### OPEN CSV
+        ### ABRE CSV
         with open(filecsv, 'r') as csvfile:
             csv_reader = csv.reader(csvfile)
 
@@ -182,15 +181,15 @@ def install():
             package = str(sys.argv[2])
             links = []
             packages = []
-            ### OPEN CSV
+            ### ABRE CSV
             with open(filecsv, 'r') as csvfile:
                 csv_reader = csv.reader(csvfile)
 
                 for line in csv_reader:
                     if package in line[1]:
                        found = True
-                       links.append(url + line[0] + line[1])         # Links for download
-                       packages.append(line[1])   # Package names
+                       links.append(url + line[0] + line[1])   # Links para download
+                       packages.append(line[1])   # Nomes de pacotes
 
                 if found:
                     pkgcount = packages.__len__()
@@ -205,7 +204,7 @@ def install():
                         else:
                             exit(0)
                     else:
-                        # Make pkglist
+                        # Cria lista de pacotes
                         if pkgcount == 2:
                             pkglist = "'" + packages[0].replace('.mz', '') + "' e '" + packages[1].replace('.mz', '') + "'."
                         else:
@@ -225,7 +224,7 @@ def install():
                             else:
                                 exit(0)
 
-                else: # if not found
+                else: # found == FALSE
                     print(package_not_found)
 
     else:
@@ -273,7 +272,7 @@ def show():
         global found
         package = str(sys.argv[2])
 
-        ### OPEN CSV
+        ### ABRE CSV
         with open(filecsv, 'r') as csvfile:
             csv_reader = csv.reader(csvfile)
 
@@ -284,7 +283,7 @@ def show():
                     pkgname = line[1].split('-')[0]
                     version = line[1].replace(pkgname + '-','').replace('.mz','')
 
-                    # Trying obtains .desc
+                    # Tentando obter o .desc
                     internet = internet_on()
                     nodesc = True
                     if not line[2] == '':
@@ -295,7 +294,7 @@ def show():
                                 nodesc = False
                                 text = r.text
 
-                    # Set maintainer and desc
+                    # Armazena o mantenedor e a descrição
                     if nodesc:
                         maintainer = '(não identificado)'
                         desc = 'A descrição deste pacote não está disponível!'
@@ -328,7 +327,7 @@ def update():
         t = threading.Thread(target=animate)
         t.start()
 
-        ### UPDATE WEB
+        ### ATUALIZAÇÃO WEB
         r = requests.get(url)
         
         soup = BeautifulSoup(r.content, 'html.parser')
@@ -395,7 +394,7 @@ def checkdesc():
         t = threading.Thread(target=animate)
         t.start()
 
-        ### OPEN CSV
+        ### ABRE CSV
         with open(filecsv, 'r') as csvfile:
             csv_reader = csv.reader(csvfile)
 
@@ -416,9 +415,9 @@ def checkdesc():
         print(please_connect)
         exit(0)
 
-##------------------ END CHOOSE-FUNCTIONS ------------->
+##------------ FIM FUNÇÕES DE OPÇÔES DO MENU ---------->
 
-#------------------- END FUNCTIONS -------------------->
+#------------------- FIM FUNÇÕES ---------------------->
 
 try:
     check()

--- a/mz_pt_BR
+++ b/mz_pt_BR
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+########################################################                                                                            #
+# mz python3 - v1.0.2                                  #
+# Autor: Diego Sarzi <diegosarzi@gmail.com> - 2019     #
+# Atualização: Vovolinux - 2019                        #
+# Licença: Todos os arquivos : MIT                     #
+########################################################
+
+#------------------- VARIABLES ------------------------>
+
+# Diretórios
+url     = 'http://mazonos.com/packages/' # Repositório oficial
+filecsv = '/var/lib/mz/mz_base.csv'      # Lista de pacotes do repositório
+dircsv  = '/var/lib/mz/'                 # Diretório para o arquivo .csv
+dirlist = '/var/lib/banana/list/'        # Diretório para o arquivo .list
+
+# Flags
+found = False
+done  = False
+
+# Strings
+choose            = ''
+textAnimate       = ''
+please_connect    = 'Por favor, verifique sua conexão com a internet!'
+package_not_found = 'Pacote não encontrado.'
+
+# Arrays
+chooses = [
+    's', 'search',
+    'i', 'install',
+    'r', 'remove',
+    'w', 'show',
+    'u', 'update',
+    'g', 'upgrade',
+    'c', 'checkdesc'
+    ]
+
+modules = ['requests', 'bs4']
+
+#------------------- END VARIABLES -------------------->
+
+
+#------------------- IMPORTS -------------------------->
+
+import sys, os, csv, threading, itertools, time, re
+
+'''
+Loop em modules:
+    FUNÇÃO..: Instalar módulos do python3.
+    DATA....: 01/07/2019
+    CRÉDITOS: José Almeida <@joseafga>
+              Rubens <@rubenss>
+              Vovolinux <suporte@vovolinux.com.br>
+'''
+
+for module in modules:
+    try:
+        __import__(module)
+    except Exception as e:
+        print('Instalando módulos..')
+        os.system('pip3 install ' + str(module))
+        os.system('clear')
+        
+import requests, bs4
+
+from urllib.request import urlopen
+from bs4 import BeautifulSoup
+
+#------------------- END IMPORTS ---------------------->
+
+
+
+#------------------- FUNCTIONS ------------------------>
+
+def check():
+    # Checks if the folder exists
+    if not os.path.isdir(dircsv):
+        os.mkdir(dircsv)
+        print('Criando diretório ' + dircsv + '.')
+
+    # Checks if the file exists
+    if not os.path.isfile(filecsv):
+        os.system('touch ' + filecsv)
+        print('Criando arquivo ' + filecsv + '.')
+        os.system('clear')
+        update()
+        
+
+def main():
+    try:
+        sys.argv[1]
+    except IndexError:
+        menu()
+        exit(0)
+    else:
+        global choose
+        choose = str(sys.argv[1])
+        
+
+def menu():
+    print(''' mz 1.0.0.1 (amd64)
+ 'mz' é um gerenciador de pacotes de linha de comando e fornece comandos 
+  para procurar e gerenciar pacotes utilizando o bananapkg.
+
+ OPÇÕES:
+ s | search    - Pesquisa pelo nome do pacote.
+ i | install   - Instala o pacote.
+ r | remove    - Remove o pacote.
+ w | show      - Exibe a descrição do pacote.
+ u | update    - Atualiza a lista de pacotes do repositório online. Precisa de internet.
+ g | upgrade   - Atualização automática da base do sistema e correções de bugs.
+ c | checkdesc - Procura por pacotes sem descrição no repositório online.
+ 
+ Uso: mz [opção] pacote
+''')
+
+
+def internet_on():
+    try:
+        response = urlopen('https://www.google.com/', timeout=10)
+        return True
+    except:
+        return False
+
+
+def animate():
+    for c in itertools.cycle(['|', '/', '-', '\\']):
+        if done:
+            break
+
+        sys.stdout.write('\r' + textAnimate + c)
+        sys.stdout.flush()
+        time.sleep(0.1)
+    
+    text = textAnimate.replace('Pesquisando...','Pesquisa ').replace('Atualizando... ','Atualização ') + 'concluída!'
+    sys.stdout.write('\r' + text + '\n')
+
+
+##------------------ CHOOSE-FUNCTIONS ----------------->
+
+def s():
+    search()
+        
+def search():
+    try:
+        sys.argv[2]
+    except IndexError:
+        menu()
+        exit(0)
+    else:
+        global found
+        package = str(sys.argv[2])
+
+        ### OPEN CSV
+        with open(filecsv, 'r') as csvfile:
+            csv_reader = csv.reader(csvfile)
+
+            count = 0
+            for line in csv_reader:
+                if package in line[1]:
+                    count += 1
+                    print(line[1].replace('.mz', ''))
+                    found = True
+            print(str(count) + ' pacote(s) encontrado(s).')
+
+            if not found:
+                print(package_not_found)
+                
+def i():
+    install()
+                
+def install():
+    if internet_on():
+        try:
+            sys.argv[2]
+        except IndexError:
+            menu()
+            exit(0)
+        else:
+            global found
+            package = str(sys.argv[2])
+            links = []
+            packages = []
+            ### OPEN CSV
+            with open(filecsv, 'r') as csvfile:
+                csv_reader = csv.reader(csvfile)
+
+                for line in csv_reader:
+                    if package in line[1]:
+                       found = True
+                       links.append(url + line[0] + line[1])         # Links for download
+                       packages.append(line[1])   # Package names
+
+                if found:
+                    pkgcount = packages.__len__()
+                    pkglist = ''
+
+                    if pkgcount == 1:
+                        install = input('Deseja instalar ' + packages[0].replace('.mz', '') + ' ? [S/n] : ')
+                        if install == 'S' or install == 's':
+                            os.system('wget -O /tmp/' + packages[0] + ' ' + links[0])
+                            os.system('banana install ' + '/tmp/' + packages[0])
+                            os.system('rm ' + '/tmp/' + packages[0])
+                        else:
+                            exit(0)
+                    else:
+                        # Make pkglist
+                        if pkgcount == 2:
+                            pkglist = "'" + packages[0].replace('.mz', '') + "' e '" + packages[1].replace('.mz', '') + "'."
+                        else:
+                            for p in packages:
+                                 pkglist += (p + ', ')
+
+                            pkglist = pkglist[:-2] + '.'
+
+                        print(str(pkgcount) + ' pacotes encontrados: ' + pkglist.replace('.mz', ''))
+
+                        install = input('Deseja instalar TODOS os pacotes ? [S/n] : ')
+                        if install == 'S' or install == 's':
+                            for p in range(pkgcount):
+                                os.system('wget -O /tmp/' + packages[p] + ' ' + links[p])
+                                os.system('banana install ' +  '/tmp/' + packages[p])
+                                os.system('rm ' + '/tmp/' + packages[p])
+                            else:
+                                exit(0)
+
+                else: # if not found
+                    print(package_not_found)
+
+    else:
+        print(please_connect)
+        exit(0)
+
+def r():
+    remove()
+
+def remove():
+    try:
+        sys.argv[2]
+    except IndexError:
+        menu()
+        exit(0)
+    else:
+        global found
+        onlyfiles = [f for f in os.listdir(dirlist) if os.path.isfile(os.path.join(dirlist, f))]
+        r = re.compile(sys.argv[2] + '.*')
+        newlist = list(filter(r.match, onlyfiles))
+
+        if newlist:
+            found = True
+            for pack in newlist:
+                package = pack.replace('.list', '')
+                remove  = input('Deseja remover ' + package + '? [S/n] : ')
+                if remove == 'S' or remove == 's':
+                    os.system('banana remove ' + package + ' -y')
+                else:
+                    exit(0)
+
+        if not found:
+            print(package_not_found)
+
+def w():
+    show()
+    
+def show():
+    try:
+        sys.argv[2]
+    except IndexError:
+        menu()
+        exit(0)
+    else:
+        global found
+        package = str(sys.argv[2])
+
+        ### OPEN CSV
+        with open(filecsv, 'r') as csvfile:
+            csv_reader = csv.reader(csvfile)
+
+            for line in csv_reader:
+                if package in line[1]:
+                    found = True
+
+                    pkgname = line[1].split('-')[0]
+                    version = line[1].replace(pkgname + '-','').replace('.mz','')
+
+                    # Trying obtains .desc
+                    internet = internet_on()
+                    nodesc = True
+                    if not line[2] == '':
+                        if internet:
+                            r = requests.get(url + line[0] + line[2])
+                            if not r.status_code == 404:
+                                # File not found (404 error) - pkgname-version.desc
+                                nodesc = False
+                                text = r.text
+
+                    # Set maintainer and desc
+                    if nodesc:
+                        maintainer = '(não identificado)'
+                        desc = 'A descrição deste pacote não está disponível!'
+
+                        if not internet:
+                            desc += '\n' + please_connect
+                    else:
+                        maintainer = (re.findall('maintainer.*', text)[0]).replace("'", '').replace('maintainer=', '').replace('"', '')
+                        desc = ((text.split('|')[2]).replace('#', '').replace('=', '').replace('desc"', ''))[:-2]
+
+                    print('Nome do Pacote: ' + pkgname)
+                    print('Versão........: ' + version)
+                    print('Mantenedor....: ' + maintainer)
+                    print(desc)
+                    print('-------------------------------------------------------------------------\n')
+
+            if not found:
+                print(package_not_found)
+
+def u():
+    update()
+
+def update():
+    if internet_on():
+        global textAnimate
+        global done
+
+        textAnimate = 'Atualizando... '
+
+        t = threading.Thread(target=animate)
+        t.start()
+
+        ### UPDATE WEB
+        r = requests.get(url)
+        
+        soup = BeautifulSoup(r.content, 'html.parser')
+        links = soup.find_all('a')
+        
+        if os.path.isfile(filecsv):
+            os.system('rm ' + filecsv)
+
+        for link in links:
+            if '/' in link.text:
+                urls = url + link.text
+                r = requests.get(urls)
+
+                soups = BeautifulSoup(r.content, 'html.parser')
+                linkss = soups.find_all('a')
+                
+                folder = link.text
+                mz = ''
+                desc = ''
+                sha256 = ''
+
+                for l in linkss:
+                    if '.mz' in l.text:
+                        if l.text.endswith(('.mz')):
+                            mz = l.text
+                       
+                        if l.text.endswith(('.desc')):
+                            desc = l.text
+
+                        if l.text.endswith(('.sha256')):
+                            sha256 = l.text
+                        
+                        if mz != '' and sha256 != '':
+                            with open(filecsv, 'a') as new_file:
+                                csv_writer = csv.writer(new_file)
+                                csv_writer.writerow([folder,mz,desc,sha256])
+                                mz = ''
+                                desc = ''
+                                sha256 = ''
+        done = True
+    else:
+        print(please_connect)
+
+def g():
+    upgrade()
+
+def upgrade():
+    print('Atualizando...')
+
+def c():
+    checkdesc()
+
+def checkdesc():
+    if internet_on():
+        update()
+
+        global textAnimate
+        global done
+
+        found = False
+        nodescs = []
+
+        textAnimate = 'Pesquisando... '
+        t = threading.Thread(target=animate)
+        t.start()
+
+        ### OPEN CSV
+        with open(filecsv, 'r') as csvfile:
+            csv_reader = csv.reader(csvfile)
+
+            for line in csv_reader:
+                if line[2] == '':
+                    found = True
+                    nodescs.append(' ' + line[0] + line[1] + '.desc -> não encontrado!')
+            done = True
+
+        if found:
+            print('Os seguintes pacotes não possuem o arquivo .desc:')
+            for n in nodescs:
+                print(n)
+        else:
+            print('Todos os pacotes OK!')
+
+    else:
+        print(please_connect)
+        exit(0)
+
+##------------------ END CHOOSE-FUNCTIONS ------------->
+
+#------------------- END FUNCTIONS -------------------->
+
+try:
+    check()
+
+    main()
+
+    if choose in chooses:
+        functions = locals()
+        functions[choose]()
+    else:
+        menu()
+        print('Opção \"' + choose + '\" inválida!')
+
+except KeyboardInterrupt:
+    print('\n')
+    exit(0)
+


### PR DESCRIPTION
Quando o mz encontrava apenas um pacote, o link gerado para download repetia o path para packages.
Também foi corrigido o cabeçalho e incluída um arquivo do mz em pt_BR.
Exemplo do erro:
```
root [ /home/vovomazon ]# mz i google
You like install google_chrome-71.0.3578.98-1 ? [Y/n] : y
--2019-07-16 11:32:20--  http://mazonos.com/packages/http://mazonos.com/packages/extra/google_chrome-71.0.3578.98-1.mz
Resolvendo mazonos.com... 107.180.51.6
Conectando-se a mazonos.com|107.180.51.6|:80... conectado.
A requisição HTTP foi enviada, aguardando resposta... 404 Not Found
2019-07-16 11:32:21 ERRO 404: Not Found.

tar: Este não parece ser um arquivo-tar
tar: ./info/desc: Não foi encontrado no arquivo-tar
tar: Saindo com status de falha em razão de erros anteriores
[ERROR!] I could not unzip the file desc.
```